### PR TITLE
fix(ci): package release tarballs in the build job

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -48,11 +48,16 @@ jobs:
           GOARCH: ${{ matrix.arch }}
         run: make build
 
+      - name: Package
+        run: |
+          tar -czf ${{ env.BINARY_NAME }}-${{ matrix.platform }}-${{ matrix.arch }}.tar.gz ${{ env.BINARY_NAME }}
+          sha256sum ${{ env.BINARY_NAME }}-${{ matrix.platform }}-${{ matrix.arch }}.tar.gz > ${{ env.BINARY_NAME }}-${{ matrix.platform }}-${{ matrix.arch }}.tar.gz.sha256
+
       - name: Upload artifacts
         uses: actions/upload-artifact@v7
         with:
           name: ${{ env.BINARY_NAME }}-${{ matrix.platform }}-${{ matrix.arch }}
-          path: ${{ env.BINARY_NAME }}
+          path: ${{ env.BINARY_NAME }}-${{ matrix.platform }}-${{ matrix.arch }}.tar.gz*
           if-no-files-found: error
 
   container:
@@ -111,18 +116,7 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           pattern: ${{ env.BINARY_NAME }}-*
-
-      - name: Package
-        run: |
-          for folder in ./*; do
-            if [ -d "$folder" ]; then
-              echo "Processing folder: $folder"
-              cd $folder
-              tar -czf ../$folder.tar.gz -T <(\ls -1)
-              cd ..
-              sha256sum $folder.tar.gz > $folder.tar.gz.sha256
-            fi
-          done
+          merge-multiple: true
 
       - name: Release
         uses: svenstaro/upload-release-action@v2


### PR DESCRIPTION
download-artifact v5+ flattens single-artifact downloads into the workspace root instead of per-artifact directories, so the release job's `for folder in ./*` packaging loop found nothing and the v2.1.0 asset upload failed (`No files matching the glob pattern found`), while the binary build and the ghcr image push succeeded.

This moves packaging into the build job, where `matrix.platform`/`matrix.arch` are known: each artifact now contains its final `.tar.gz` + `.sha256`, and the release job just downloads with `merge-multiple: true` and uploads. Asset names are unchanged (`ovh-exporter-linux-amd64.tar.gz`).

The v2.1.0 assets themselves are being repaired by direct upload; this fixes every future tag.

Ref: https://app.notion.com/p/wiremind/ovh-exporter-modernize-repo-Go-toolchain-deps-CI-and-release-39fdcbda9c358158b827feaf5429144d