### PR TITLE
feat: expose ovh_exporter_cloud_project_info metric

### DIFF
--- a/pkg/network/serve.go
+++ b/pkg/network/serve.go
@@ -50,6 +50,7 @@ func pingHandler(w http.ResponseWriter, req *http.Request) {
 
 func initializeMetrics() {
 	prometheus.MustRegister(apiErrors)
+	prometheus.MustRegister(cloudProjectInfo)
 	prometheus.MustRegister(cloudProjectInstanceBilling)
 	prometheus.MustRegister(cloudProjectVolumeInfo)
 	prometheus.MustRegister(cloudProjectLoadBalancerInfo)
@@ -60,6 +61,9 @@ func initializeMetrics() {
 }
 
 func updateMetrics(ovhClient *ovh.Client) {
+	cloudProjectInfo.Reset()
+	updateCloudProjectInfo(ovhClient)
+
 	cloudProjectInstanceBilling.Reset()
 	updateCloudProviderInstanceBilling(ovhClient)
 

--- a/pkg/network/serve_cloud_project_info.go
+++ b/pkg/network/serve_cloud_project_info.go
@@ -1,0 +1,51 @@
+package network
+
+import (
+	"github.com/ovh/go-ovh/ovh"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/wiremind/ovh-exporter/pkg/ovhsdk/api"
+)
+
+var cloudProjectInfo = prometheus.NewGaugeVec(
+	prometheus.GaugeOpts{
+		Name: "ovh_exporter_cloud_project_info",
+		Help: "Information about watched OVH cloud projects, value is always 1. Join on project_id to resolve the human-readable description.",
+	},
+	[]string{"project_id", "description", "status"},
+)
+
+func updateCloudProjectInfoPerProjectID(ovhClient *ovh.Client, projectID string) {
+	logger.Info().Msgf("updating cloud project info for project %s", projectID)
+
+	project, err := api.GetCloudProject(ovhClient, projectID)
+	if err != nil {
+		apiErrors.WithLabelValues("cloud_project_info").Inc()
+		logger.Error().Msgf("failed to retrieve cloud project %s: %v", projectID, err)
+		return
+	}
+
+	description := "undefined"
+	if project.Description != nil {
+		description = *project.Description
+	}
+
+	cloudProjectInfo.With(prometheus.Labels{
+		"project_id":  project.ProjectID,
+		"description": description,
+		"status":      project.Status,
+	}).Set(1)
+}
+
+func updateCloudProjectInfo(ovhClient *ovh.Client) {
+	seen := make(map[string]bool)
+	for _, envVar := range []string{"OVH_CLOUD_PROJECT_INSTANCE_BILLING_PROJECT_IDS", "OVH_CLOUD_PROJECT_INVENTORY_PROJECT_IDS"} {
+		for _, projectID := range projectIDsFromEnv(envVar) {
+			if seen[projectID] {
+				continue
+			}
+			seen[projectID] = true
+
+			updateCloudProjectInfoPerProjectID(ovhClient, projectID)
+		}
+	}
+}

--- a/pkg/ovhsdk/api/cloud_project.go
+++ b/pkg/ovhsdk/api/cloud_project.go
@@ -1,0 +1,19 @@
+package api
+
+import (
+	"github.com/ovh/go-ovh/ovh"
+	"github.com/wiremind/ovh-exporter/pkg/ovhsdk/models"
+)
+
+func GetCloudProject(client *ovh.Client, projectID string) (models.CloudProject, error) {
+	var project models.CloudProject
+
+	endpoint := "/cloud/project/" + projectID
+
+	err := client.Get(endpoint, &project)
+	if err != nil {
+		return project, err
+	}
+
+	return project, nil
+}

--- a/pkg/ovhsdk/models/cloud_project.go
+++ b/pkg/ovhsdk/models/cloud_project.go
@@ -1,0 +1,9 @@
+package models
+
+type CloudProject struct {
+	ProjectID   string  `json:"project_id"`
+	ProjectName *string `json:"projectName"` // Use *string for nullable string
+	Description *string `json:"description"` // Use *string for nullable string
+	PlanCode    string  `json:"planCode"`
+	Status      string  `json:"status"` // Allowed: "creating", "deleted", "deleting", "ok", "suspended"
+}


### PR DESCRIPTION
## Why

Alerts built on `ovh_exporter_cloud_project_instance_billing` and `ovh_exporter_services_savingsplans_subscribed_plan_size` only have the opaque OVH `project_id` to identify a project. This currently forces a static `project_id` → cluster-name `label_replace` chain in the alerting rules (wiremind-services-configuration MR !7389), which has to be maintained by hand.

## What

New info-style gauge (value always 1):

```
ovh_exporter_cloud_project_info{project_id="bb5c1792...", description="eu-paxone-hermes", status="ok"} 1
```

- `description` comes from `GET /cloud/project/{id}` and is the human-readable project name shown in the OVH manager (verified: our projects are named after the cluster, e.g. `eu-paxone-hermes`); falls back to `undefined` when null.
- `status` is included as a bonus (`ok`, `suspended`, ...).
- The watched project list reuses `OVH_CLOUD_PROJECT_INSTANCE_BILLING_PROJECT_IDS`; the metric follows the same Reset-on-refresh lifecycle as the others.

## Usage

```promql
some_metric * on(project_id) group_left(description) ovh_exporter_cloud_project_info
```

Once released and deployed, the static mapping in the alert rules can be replaced by this join.