### PR TITLE
fix(credentials): grant GET /cloud/project/* for the project info metric

### DIFF
--- a/pkg/credentials/generate.go
+++ b/pkg/credentials/generate.go
@@ -31,6 +31,7 @@ type APIKeyRight struct {
 }
 
 var apiKeyRights = []APIKeyRight{
+	{Method: "GET", Endpoint: "/cloud/project/*"},
 	{Method: "GET", Endpoint: "/cloud/project/*/flavor/*"},
 	{Method: "GET", Endpoint: "/cloud/project/*/instance"},
 	{Method: "GET", Endpoint: "/cloud/project/*/instance/*"},


### PR DESCRIPTION
The `cloud_project_info` collector (v2.2.0, #47) calls `GET /cloud/project/{id}`, but the rules baked into the `credentials` subcommand did not include that path. Tokens created from the generated link therefore fail with `Client::Forbidden: "This call has not been granted"` and `ovh_exporter_cloud_project_info` stays empty (`ovh_exporter_api_errors_total{collector="cloud_project_info"}` increments instead) — observed in prod on v2.3.0.

Adds `GET=/cloud/project/*` to the generated createToken link.

Note: existing tokens are unaffected — OVH consumer key rules are fixed at creation, so a new token must be generated from the updated link (or by appending `&GET=/cloud/project/*` to the old one) and rolled into the deployment secret.