### PR TITLE
fix(metrics): count API errors in billing, savings plan and dedicated collectors

### DIFF
--- a/pkg/network/serve_cloud_project_instance_billing.go
+++ b/pkg/network/serve_cloud_project_instance_billing.go
@@ -64,12 +64,14 @@ func updateCloudProviderInstanceBillingPerProjectID(ovhClient *ovh.Client, proje
 
 	projectInstances, err := api.GetCloudProjectInstances(ovhClient, projectID)
 	if err != nil {
+		apiErrors.WithLabelValues("cloud_project_instance_billing").Inc()
 		logger.Error().Msgf("failed to retrieve instances: %v", err)
 		return
 	}
 
 	flavors, err := api.GetCloudProjectFlavorsPerInstances(ovhClient, projectID, projectInstances)
 	if err != nil {
+		apiErrors.WithLabelValues("cloud_project_instance_billing").Inc()
 		logger.Error().Msgf("failed to retrieve flavors: %v", err)
 		return
 	}

--- a/pkg/network/serve_dedicated_server_subscription.go
+++ b/pkg/network/serve_dedicated_server_subscription.go
@@ -84,6 +84,7 @@ func updateDedicatedServerSubscription(ovhClient *ovh.Client, server models.Serv
 
 	serviceInfos, err := api.GetDedicatedServerServiceInfos(ovhClient, server.ID)
 	if err != nil {
+		apiErrors.WithLabelValues("dedicated_server_subscription").Inc()
 		logger.Error().Msgf("failed to retrieve dedicated server serviceinfos: %v", err)
 		return
 	}
@@ -101,6 +102,7 @@ func updateDedicatedServersSubscription(ovhClient *ovh.Client) {
 
 	servers, err := api.GetDedicatedServers(ovhClient)
 	if err != nil {
+		apiErrors.WithLabelValues("dedicated_server_subscription").Inc()
 		logger.Error().Msgf("failed to retrieve servers: %v", err)
 		return
 	}

--- a/pkg/network/serve_services_savingsplans_subscribed.go
+++ b/pkg/network/serve_services_savingsplans_subscribed.go
@@ -1,7 +1,6 @@
 package network
 
 import (
-	"log"
 	"strconv"
 	"strings"
 
@@ -50,6 +49,7 @@ func updateServiceSavingsPlansSubscribed(ovhClient *ovh.Client, serviceID int, p
 	// Retrieve the savings plans for the given service
 	savingsPlans, err := api.GetServicesSavingPlansSubscribed(ovhClient, serviceID)
 	if err != nil {
+		apiErrors.WithLabelValues("services_savingsplans_subscribed").Inc()
 		logger.Error().Msgf("failed to retrieve savings plans for service %d: %v", serviceID, err)
 		return
 	}
@@ -92,8 +92,8 @@ func updateAllServicesSavingsPlansSubscribed(ovhClient *ovh.Client) {
 
 		result, err := api.GetServices(ovhClient, opts)
 		if err != nil {
-
-			log.Printf("error retrieving services for projectID %s: %v", projectID, err)
+			apiErrors.WithLabelValues("services_savingsplans_subscribed").Inc()
+			logger.Error().Msgf("error retrieving services for projectID %s: %v", projectID, err)
 			continue
 		}
 		for _, service := range result {


### PR DESCRIPTION
`ovh_exporter_api_errors_total` was only incremented by the cloud_project_info / volume / loadbalancer / floatingip collectors. The instance-billing, savings-plans and dedicated-server collectors only logged their API failures — yet their gauges are `Reset()` at every refresh, so a failing collector silently empties the metrics that the `SavingsPlan*` / `DedicatedServerDeletionImminent` alerts rely on, and the `OVHExporterAPIErrors` safety-net alert (wiremind-services-configuration !7389) could never fire for exactly those paths.

Adds `apiErrors.WithLabelValues(...).Inc()` to every error path in:
- `serve_cloud_project_instance_billing.go` (collector `cloud_project_instance_billing`)
- `serve_services_savingsplans_subscribed.go` (collector `services_savingsplans_subscribed`; also migrates a stray `log.Printf` to the structured logger)
- `serve_dedicated_server_subscription.go` (collector `dedicated_server_subscription`)