### PR TITLE
fix(metrics): invalidate per fetched scope instead of global Reset

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,6 +23,21 @@ jobs:
         with:
           version: v2.12.2
 
+  test:
+    name: Go tests
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Go
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+
+      - name: go test
+        run: make test
+
   container:
     name: Containerfile
     runs-on: ubuntu-24.04

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,11 @@ ${BINARY_NAME}: ${BINARY_FILES}
 	${GO} build ${GO_GCFLAGS} ${GO_LDFLAGS} -o $@ cmd/${BINARY_NAME}/*.go
 	strip -x $@
 
+## Runs all the go tests in the application.
+.PHONY: test
+test:
+	${GO} test ./...
+
 ## Lints all the go code in the application.
 .PHONY: lint
 lint: dependencies

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect

--- a/pkg/network/scope.go
+++ b/pkg/network/scope.go
@@ -1,0 +1,84 @@
+package network
+
+import "github.com/prometheus/client_golang/prometheus"
+
+// Collector names identify a collector to the apiErrors counter and to log
+// messages. Kept as constants (instead of repeating the string at every
+// call site) so a typo can't silently split one collector's errors across
+// two different label values on ovh_exporter_api_errors_total.
+const (
+	CollectorCloudProjectInfo               = "cloud_project_info"
+	CollectorCloudProjectInstanceBilling    = "cloud_project_instance_billing"
+	CollectorCloudProjectVolume             = "cloud_project_volume"
+	CollectorCloudProjectLoadBalancer       = "cloud_project_loadbalancer"
+	CollectorCloudProjectFloatingIP         = "cloud_project_floatingip"
+	CollectorDedicatedServerSubscription    = "dedicated_server_subscription"
+	CollectorServicesSavingsPlansSubscribed = "services_savingsplans_subscribed"
+)
+
+// Scope identifies which label combination a RefreshScope call clears
+// before repopulating it. Implementations own the actual label-key strings
+// once, so call sites pass typed fields (ProjectID, Region...) instead of
+// repeating raw label keys ("project_id"...) in a prometheus.Labels map at
+// every call site.
+type Scope interface {
+	Labels() prometheus.Labels
+}
+
+// ProjectScope scopes a gauge to a single OVH cloud project.
+type ProjectScope struct{ ProjectID string }
+
+func (s ProjectScope) Labels() prometheus.Labels {
+	return prometheus.Labels{"project_id": s.ProjectID}
+}
+
+// ProjectRegionScope scopes a gauge to a single region of a cloud project.
+type ProjectRegionScope struct{ ProjectID, Region string }
+
+func (s ProjectRegionScope) Labels() prometheus.Labels {
+	return prometheus.Labels{"project_id": s.ProjectID, "region": s.Region}
+}
+
+// ServiceScope scopes a gauge to a single OVH service.
+type ServiceScope struct{ ServiceID string }
+
+func (s ServiceScope) Labels() prometheus.Labels {
+	return prometheus.Labels{"service_id": s.ServiceID}
+}
+
+// GlobalScope clears every series on the given gauges, equivalent to
+// Reset() but gated on fetch succeeding first. Use it when there is no
+// natural per-item label to key off, e.g. a flat, fully-enumerated list.
+type GlobalScope struct{}
+
+func (GlobalScope) Labels() prometheus.Labels { return prometheus.Labels{} }
+
+// RefreshScope refreshes one scope of one or more gauges from a fetch that
+// may fail. On success it clears any series matching scope on every gauge
+// passed in, then repopulates them via set for each fetched item. On
+// failure it leaves all gauges untouched, so the previous values keep
+// serving instead of a hole appearing until the next successful refresh,
+// and reports the failure via apiErrors under collector.
+func RefreshScope[T any](
+	scope Scope,
+	collector string,
+	fetch func() ([]T, error),
+	set func(T),
+	gauges ...*prometheus.GaugeVec,
+) error {
+	items, err := fetch()
+	if err != nil {
+		apiErrors.WithLabelValues(collector).Inc()
+		return err
+	}
+
+	labels := scope.Labels()
+	for _, gauge := range gauges {
+		gauge.DeletePartialMatch(labels)
+	}
+	for _, item := range items {
+		set(item)
+	}
+
+	return nil
+}

--- a/pkg/network/scope_test.go
+++ b/pkg/network/scope_test.go
@@ -1,0 +1,262 @@
+package network
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+// testScope is a throwaway Scope implementation used only to exercise
+// RefreshScope's generic mechanism, independent of any real gauge's label
+// keys (see ProjectScope/ServiceScope/GlobalScope in scope.go for the
+// production ones).
+type testScope prometheus.Labels
+
+func (s testScope) Labels() prometheus.Labels { return prometheus.Labels(s) }
+
+func TestRefreshScope(t *testing.T) {
+	cases := map[string]struct {
+		seed           map[[2]string]float64 // [scope, item] -> value, set on the gauge before RefreshScope runs
+		scope          Scope
+		itemScopeValue string   // "scope" label used by set for freshly fetched items, mirrors a real collector capturing projectID from its enclosing closure
+		fetchItems     []string // items returned by the fetch; nil combined with fetchErr means "fetch failed"
+		fetchErr       error
+		wantErr        bool
+		wantSeries     string // full expected Prometheus text exposition after RefreshScope runs
+	}{
+		"fetch succeeds: stale items in scope are cleared, fresh ones set": {
+			seed: map[[2]string]float64{
+				{"p1", "x"}: 1,
+				{"p1", "y"}: 1,
+				{"p2", "z"}: 1,
+			},
+			scope:          testScope{"scope": "p1"},
+			itemScopeValue: "p1",
+			fetchItems:     []string{"x2"},
+			wantSeries: `
+				# HELP test_gauge test gauge
+				# TYPE test_gauge gauge
+				test_gauge{item="x2",scope="p1"} 1
+				test_gauge{item="z",scope="p2"} 1
+			`,
+		},
+		"fetch fails: previous values in scope are kept untouched": {
+			seed: map[[2]string]float64{
+				{"p1", "x"}: 1,
+				{"p2", "z"}: 1,
+			},
+			scope:    testScope{"scope": "p1"},
+			fetchErr: errors.New("ovh api down"),
+			wantErr:  true,
+			wantSeries: `
+				# HELP test_gauge test gauge
+				# TYPE test_gauge gauge
+				test_gauge{item="x",scope="p1"} 1
+				test_gauge{item="z",scope="p2"} 1
+			`,
+		},
+		"fetch succeeds with no items: scope is cleared and stays empty": {
+			seed: map[[2]string]float64{
+				{"p1", "x"}: 1,
+				{"p2", "z"}: 1,
+			},
+			scope:      testScope{"scope": "p1"},
+			fetchItems: nil,
+			wantSeries: `
+				# HELP test_gauge test gauge
+				# TYPE test_gauge gauge
+				test_gauge{item="z",scope="p2"} 1
+			`,
+		},
+		"GlobalScope on success clears every series, like Reset": {
+			seed: map[[2]string]float64{
+				{"p1", "x"}: 1,
+				{"p2", "z"}: 1,
+			},
+			scope:      GlobalScope{},
+			fetchItems: []string{"w"},
+			wantSeries: `
+				# HELP test_gauge test gauge
+				# TYPE test_gauge gauge
+				test_gauge{item="w",scope=""} 1
+			`,
+		},
+		"fetch fails with GlobalScope: nothing is reset, unlike the old Reset() call": {
+			seed: map[[2]string]float64{
+				{"p1", "x"}: 1,
+				{"p2", "z"}: 1,
+			},
+			scope:    GlobalScope{},
+			fetchErr: errors.New("ovh api down"),
+			wantErr:  true,
+			wantSeries: `
+				# HELP test_gauge test gauge
+				# TYPE test_gauge gauge
+				test_gauge{item="x",scope="p1"} 1
+				test_gauge{item="z",scope="p2"} 1
+			`,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			gauge := prometheus.NewGaugeVec(
+				prometheus.GaugeOpts{Name: "test_gauge", Help: "test gauge"},
+				[]string{"scope", "item"},
+			)
+			for key, value := range tc.seed {
+				gauge.With(prometheus.Labels{"scope": key[0], "item": key[1]}).Set(value)
+			}
+
+			err := RefreshScope(
+				tc.scope,
+				"test_collector",
+				func() ([]string, error) {
+					if tc.fetchErr != nil {
+						return nil, tc.fetchErr
+					}
+					return tc.fetchItems, nil
+				},
+				func(item string) {
+					gauge.With(prometheus.Labels{"scope": tc.itemScopeValue, "item": item}).Set(1)
+				},
+				gauge,
+			)
+
+			if tc.wantErr && err == nil {
+				t.Fatal("expected an error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+
+			if err := testutil.CollectAndCompare(gauge, strings.NewReader(tc.wantSeries), "test_gauge"); err != nil {
+				t.Fatalf("unexpected gauge state:\n%v", err)
+			}
+		})
+	}
+}
+
+func TestRefreshScope_MultipleGaugesClearedTogether(t *testing.T) {
+	subscription := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{Name: "test_subscription", Help: "test subscription"},
+		[]string{"server_id"},
+	)
+	expiration := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{Name: "test_expiration", Help: "test expiration"},
+		[]string{"server_id"},
+	)
+	subscription.With(prometheus.Labels{"server_id": "old"}).Set(1)
+	expiration.With(prometheus.Labels{"server_id": "old"}).Set(123)
+
+	err := RefreshScope(
+		GlobalScope{},
+		"test_collector",
+		func() ([]string, error) { return []string{"new"}, nil },
+		func(serverID string) {
+			subscription.With(prometheus.Labels{"server_id": serverID}).Set(1)
+			expiration.With(prometheus.Labels{"server_id": serverID}).Set(456)
+		},
+		subscription, expiration,
+	)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if err := testutil.CollectAndCompare(subscription, strings.NewReader(`
+		# HELP test_subscription test subscription
+		# TYPE test_subscription gauge
+		test_subscription{server_id="new"} 1
+	`), "test_subscription"); err != nil {
+		t.Fatalf("unexpected subscription gauge state:\n%v", err)
+	}
+	if err := testutil.CollectAndCompare(expiration, strings.NewReader(`
+		# HELP test_expiration test expiration
+		# TYPE test_expiration gauge
+		test_expiration{server_id="new"} 456
+	`), "test_expiration"); err != nil {
+		t.Fatalf("unexpected expiration gauge state:\n%v", err)
+	}
+}
+
+// TestRefreshScope_FetchAndSetShareStateViaPointer mirrors the real pattern
+// in serve_cloud_project_instance_billing.go: fetch makes a second,
+// dependent API call (there: flavors, keyed off the instances fetch just
+// returned) and shares that extra result with set through an explicit
+// pointer, instead of an implicitly captured bare var. This pins down that
+// set only ever observes the pointer AFTER fetch has written to it.
+func TestRefreshScope_FetchAndSetShareStateViaPointer(t *testing.T) {
+	enrichment := new(string)
+
+	gauge := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{Name: "test_gauge_enrichment", Help: "h"},
+		[]string{"item", "enrichment"},
+	)
+
+	err := RefreshScope(
+		GlobalScope{},
+		"test_collector",
+		func() ([]string, error) {
+			*enrichment = "fetched-once" // written here, before any item is set
+			return []string{"a", "b"}, nil
+		},
+		func(item string) {
+			gauge.With(prometheus.Labels{"item": item, "enrichment": *enrichment}).Set(1) // read here, for every item
+		},
+		gauge,
+	)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if err := testutil.CollectAndCompare(gauge, strings.NewReader(`
+		# HELP test_gauge_enrichment h
+		# TYPE test_gauge_enrichment gauge
+		test_gauge_enrichment{enrichment="fetched-once",item="a"} 1
+		test_gauge_enrichment{enrichment="fetched-once",item="b"} 1
+	`), "test_gauge_enrichment"); err != nil {
+		t.Fatalf("unexpected gauge state:\n%v", err)
+	}
+}
+
+// TestRefreshScope_SetIsNeverCalledWhenFetchFails guards the ordering
+// RefreshScope's pointer-sharing pattern depends on: if set ran before, or
+// despite, a failed fetch, a pointer fetch was supposed to fill in (like
+// flavors above) would still be at its zero value when set reads it.
+func TestRefreshScope_SetIsNeverCalledWhenFetchFails(t *testing.T) {
+	setCalled := false
+
+	err := RefreshScope(
+		GlobalScope{},
+		"test_collector",
+		func() ([]string, error) { return nil, errors.New("boom") },
+		func(string) { setCalled = true },
+	)
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	if setCalled {
+		t.Fatal("set must not be called when fetch fails")
+	}
+}
+
+func TestRefreshScope_FetchErrorIncrementsAPIErrorsCounter(t *testing.T) {
+	before := testutil.ToFloat64(apiErrors.WithLabelValues("test_collector_counter"))
+
+	gauge := prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: "test_gauge_counter", Help: "h"}, []string{"id"})
+	_ = RefreshScope(
+		GlobalScope{},
+		"test_collector_counter",
+		func() ([]string, error) { return nil, errors.New("boom") },
+		func(string) {},
+		gauge,
+	)
+
+	after := testutil.ToFloat64(apiErrors.WithLabelValues("test_collector_counter"))
+	if after != before+1 {
+		t.Fatalf("expected apiErrors counter to increment by 1, went from %v to %v", before, after)
+	}
+}

--- a/pkg/network/serve.go
+++ b/pkg/network/serve.go
@@ -60,27 +60,18 @@ func initializeMetrics() {
 	prometheus.MustRegister(servicesSavingsPlansSubscribedPlanSize)
 }
 
+// Each collector invalidates only the label scope it has just
+// successfully re-fetched (DeletePartialMatch then set): a failed OVH
+// API call keeps the previous values instead of leaving a hole until
+// the next refresh, which made downstream alerts flap. Series for
+// scopes removed from the watch lists persist until the next restart.
 func updateMetrics(ovhClient *ovh.Client) {
-	cloudProjectInfo.Reset()
 	updateCloudProjectInfo(ovhClient)
-
-	cloudProjectInstanceBilling.Reset()
 	updateCloudProviderInstanceBilling(ovhClient)
-
-	cloudProjectVolumeInfo.Reset()
 	updateCloudProjectVolumes(ovhClient)
-
-	cloudProjectLoadBalancerInfo.Reset()
 	updateCloudProjectLoadBalancers(ovhClient)
-
-	cloudProjectFloatingIPInfo.Reset()
 	updateCloudProjectFloatingIPs(ovhClient)
-
-	dedicatedServerSubscription.Reset()
-	dedicatedServerSubscriptionExpirationTimestamp.Reset()
 	updateDedicatedServersSubscription(ovhClient)
-
-	servicesSavingsPlansSubscribedPlanSize.Reset()
 	updateAllServicesSavingsPlansSubscribed(ovhClient)
 }
 

--- a/pkg/network/serve_cloud_project_floatingip.go
+++ b/pkg/network/serve_cloud_project_floatingip.go
@@ -41,22 +41,24 @@ func setCloudProjectFloatingIPInfo(projectID string, regionName string, floating
 func updateCloudProjectFloatingIPsPerRegion(ovhClient *ovh.Client, projectID string, regionName string) {
 	logger.Info().Msgf("updating cloud project floating IPs for project %s in region %s", projectID, regionName)
 
-	floatingIPs, err := api.GetCloudProjectRegionFloatingIPs(ovhClient, projectID, regionName)
+	err := RefreshScope(
+		ProjectRegionScope{ProjectID: projectID, Region: regionName},
+		CollectorCloudProjectFloatingIP,
+		func() ([]models.FloatingIP, error) {
+			return api.GetCloudProjectRegionFloatingIPs(ovhClient, projectID, regionName)
+		},
+		func(floatingIP models.FloatingIP) { setCloudProjectFloatingIPInfo(projectID, regionName, floatingIP) },
+		cloudProjectFloatingIPInfo,
+	)
 	if err != nil {
-		apiErrors.WithLabelValues("cloud_project_floatingip").Inc()
 		logger.Error().Msgf("failed to retrieve floating IPs for project %s in region %s: %v", projectID, regionName, err)
-		return
-	}
-
-	for _, floatingIP := range floatingIPs {
-		setCloudProjectFloatingIPInfo(projectID, regionName, floatingIP)
 	}
 }
 
 func updateCloudProjectFloatingIPsPerProjectID(ovhClient *ovh.Client, projectID string) {
 	regions, err := api.GetCloudProjectRegions(ovhClient, projectID)
 	if err != nil {
-		apiErrors.WithLabelValues("cloud_project_floatingip").Inc()
+		apiErrors.WithLabelValues(CollectorCloudProjectFloatingIP).Inc()
 		logger.Error().Msgf("failed to retrieve regions for project %s: %v", projectID, err)
 		return
 	}

--- a/pkg/network/serve_cloud_project_info.go
+++ b/pkg/network/serve_cloud_project_info.go
@@ -4,6 +4,7 @@ import (
 	"github.com/ovh/go-ovh/ovh"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/wiremind/ovh-exporter/pkg/ovhsdk/api"
+	"github.com/wiremind/ovh-exporter/pkg/ovhsdk/models"
 )
 
 var cloudProjectInfo = prometheus.NewGaugeVec(
@@ -14,16 +15,7 @@ var cloudProjectInfo = prometheus.NewGaugeVec(
 	[]string{"project_id", "description", "status"},
 )
 
-func updateCloudProjectInfoPerProjectID(ovhClient *ovh.Client, projectID string) {
-	logger.Info().Msgf("updating cloud project info for project %s", projectID)
-
-	project, err := api.GetCloudProject(ovhClient, projectID)
-	if err != nil {
-		apiErrors.WithLabelValues("cloud_project_info").Inc()
-		logger.Error().Msgf("failed to retrieve cloud project %s: %v", projectID, err)
-		return
-	}
-
+func setCloudProjectInfo(project models.CloudProject) {
 	description := "undefined"
 	if project.Description != nil {
 		description = *project.Description
@@ -34,6 +26,27 @@ func updateCloudProjectInfoPerProjectID(ovhClient *ovh.Client, projectID string)
 		"description": description,
 		"status":      project.Status,
 	}).Set(1)
+}
+
+func updateCloudProjectInfoPerProjectID(ovhClient *ovh.Client, projectID string) {
+	logger.Info().Msgf("updating cloud project info for project %s", projectID)
+
+	err := RefreshScope(
+		ProjectScope{ProjectID: projectID},
+		CollectorCloudProjectInfo,
+		func() ([]models.CloudProject, error) {
+			project, err := api.GetCloudProject(ovhClient, projectID)
+			if err != nil {
+				return nil, err
+			}
+			return []models.CloudProject{project}, nil
+		},
+		setCloudProjectInfo,
+		cloudProjectInfo,
+	)
+	if err != nil {
+		logger.Error().Msgf("failed to retrieve cloud project %s: %v", projectID, err)
+	}
 }
 
 func updateCloudProjectInfo(ovhClient *ovh.Client) {

--- a/pkg/network/serve_cloud_project_instance_billing.go
+++ b/pkg/network/serve_cloud_project_instance_billing.go
@@ -62,22 +62,31 @@ func updateCloudProviderInstanceBillingPerInstance(projectID string, instance mo
 func updateCloudProviderInstanceBillingPerProjectID(ovhClient *ovh.Client, projectID string) {
 	logger.Info().Msgf("updating cloud provider instance billing for project %s", projectID)
 
-	projectInstances, err := api.GetCloudProjectInstances(ovhClient, projectID)
-	if err != nil {
-		apiErrors.WithLabelValues("cloud_project_instance_billing").Inc()
-		logger.Error().Msgf("failed to retrieve instances: %v", err)
-		return
-	}
+	// flavors is filled inside fetch, alongside the instances it describes:
+	// both calls must succeed before the gauge scope is cleared and set uses
+	// flavors to enrich each instance. Shared explicitly via a pointer
+	// between fetch and set instead of relying on implicit closure capture.
+	flavors := new([]models.Flavor)
 
-	flavors, err := api.GetCloudProjectFlavorsPerInstances(ovhClient, projectID, projectInstances)
+	err := RefreshScope(
+		ProjectScope{ProjectID: projectID},
+		CollectorCloudProjectInstanceBilling,
+		func() ([]models.InstanceSummary, error) {
+			instances, err := api.GetCloudProjectInstances(ovhClient, projectID)
+			if err != nil {
+				return nil, err
+			}
+			fetchedFlavors, err := api.GetCloudProjectFlavorsPerInstances(ovhClient, projectID, instances)
+			*flavors = fetchedFlavors
+			return instances, err
+		},
+		func(instance models.InstanceSummary) {
+			updateCloudProviderInstanceBillingPerInstance(projectID, instance, *flavors)
+		},
+		cloudProjectInstanceBilling,
+	)
 	if err != nil {
-		apiErrors.WithLabelValues("cloud_project_instance_billing").Inc()
-		logger.Error().Msgf("failed to retrieve flavors: %v", err)
-		return
-	}
-
-	for _, instance := range projectInstances {
-		updateCloudProviderInstanceBillingPerInstance(projectID, instance, flavors)
+		logger.Error().Msgf("failed to retrieve instances or flavors for project %s: %v", projectID, err)
 	}
 }
 

--- a/pkg/network/serve_cloud_project_loadbalancer.go
+++ b/pkg/network/serve_cloud_project_loadbalancer.go
@@ -30,22 +30,26 @@ func setCloudProjectLoadBalancerInfo(projectID string, regionName string, loadBa
 func updateCloudProjectLoadBalancersPerRegion(ovhClient *ovh.Client, projectID string, regionName string) {
 	logger.Info().Msgf("updating cloud project load balancers for project %s in region %s", projectID, regionName)
 
-	loadBalancers, err := api.GetCloudProjectRegionLoadBalancers(ovhClient, projectID, regionName)
+	err := RefreshScope(
+		ProjectRegionScope{ProjectID: projectID, Region: regionName},
+		CollectorCloudProjectLoadBalancer,
+		func() ([]models.LoadBalancer, error) {
+			return api.GetCloudProjectRegionLoadBalancers(ovhClient, projectID, regionName)
+		},
+		func(loadBalancer models.LoadBalancer) {
+			setCloudProjectLoadBalancerInfo(projectID, regionName, loadBalancer)
+		},
+		cloudProjectLoadBalancerInfo,
+	)
 	if err != nil {
-		apiErrors.WithLabelValues("cloud_project_loadbalancer").Inc()
 		logger.Error().Msgf("failed to retrieve load balancers for project %s in region %s: %v", projectID, regionName, err)
-		return
-	}
-
-	for _, loadBalancer := range loadBalancers {
-		setCloudProjectLoadBalancerInfo(projectID, regionName, loadBalancer)
 	}
 }
 
 func updateCloudProjectLoadBalancersPerProjectID(ovhClient *ovh.Client, projectID string) {
 	regions, err := api.GetCloudProjectRegions(ovhClient, projectID)
 	if err != nil {
-		apiErrors.WithLabelValues("cloud_project_loadbalancer").Inc()
+		apiErrors.WithLabelValues(CollectorCloudProjectLoadBalancer).Inc()
 		logger.Error().Msgf("failed to retrieve regions for project %s: %v", projectID, err)
 		return
 	}

--- a/pkg/network/serve_cloud_project_volume.go
+++ b/pkg/network/serve_cloud_project_volume.go
@@ -38,15 +38,15 @@ func setCloudProjectVolumeInfo(projectID string, volume models.Volume) {
 func updateCloudProjectVolumesPerProjectID(ovhClient *ovh.Client, projectID string) {
 	logger.Info().Msgf("updating cloud project volumes for project %s", projectID)
 
-	volumes, err := api.GetCloudProjectVolumes(ovhClient, projectID)
+	err := RefreshScope(
+		ProjectScope{ProjectID: projectID},
+		CollectorCloudProjectVolume,
+		func() ([]models.Volume, error) { return api.GetCloudProjectVolumes(ovhClient, projectID) },
+		func(volume models.Volume) { setCloudProjectVolumeInfo(projectID, volume) },
+		cloudProjectVolumeInfo,
+	)
 	if err != nil {
-		apiErrors.WithLabelValues("cloud_project_volume").Inc()
 		logger.Error().Msgf("failed to retrieve volumes for project %s: %v", projectID, err)
-		return
-	}
-
-	for _, volume := range volumes {
-		setCloudProjectVolumeInfo(projectID, volume)
 	}
 }
 

--- a/pkg/network/serve_dedicated_server_subscription.go
+++ b/pkg/network/serve_dedicated_server_subscription.go
@@ -84,7 +84,7 @@ func updateDedicatedServerSubscription(ovhClient *ovh.Client, server models.Serv
 
 	serviceInfos, err := api.GetDedicatedServerServiceInfos(ovhClient, server.ID)
 	if err != nil {
-		apiErrors.WithLabelValues("dedicated_server_subscription").Inc()
+		apiErrors.WithLabelValues(CollectorDedicatedServerSubscription).Inc()
 		logger.Error().Msgf("failed to retrieve dedicated server serviceinfos: %v", err)
 		return
 	}
@@ -100,14 +100,19 @@ func updateDedicatedServersSubscription(ovhClient *ovh.Client) {
 
 	logger.Info().Msgf("updating dedicated server subscription")
 
-	servers, err := api.GetDedicatedServers(ovhClient)
+	// The server list has no natural per-project scope to key off, so an
+	// empty scope clears both gauges entirely - but only once the list call
+	// has actually succeeded. A failure fetching one server's own service
+	// info inside updateDedicatedServerSubscription only leaves that one
+	// server stale, same as before.
+	err := RefreshScope(
+		GlobalScope{},
+		CollectorDedicatedServerSubscription,
+		func() ([]models.Server, error) { return api.GetDedicatedServers(ovhClient) },
+		func(server models.Server) { updateDedicatedServerSubscription(ovhClient, server) },
+		dedicatedServerSubscription, dedicatedServerSubscriptionExpirationTimestamp,
+	)
 	if err != nil {
-		apiErrors.WithLabelValues("dedicated_server_subscription").Inc()
 		logger.Error().Msgf("failed to retrieve servers: %v", err)
-		return
-	}
-
-	for _, server := range servers {
-		updateDedicatedServerSubscription(ovhClient, server)
 	}
 }

--- a/pkg/network/serve_services_savingsplans_subscribed.go
+++ b/pkg/network/serve_services_savingsplans_subscribed.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ovh/go-ovh/ovh"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/wiremind/ovh-exporter/pkg/ovhsdk/api"
+	"github.com/wiremind/ovh-exporter/pkg/ovhsdk/models"
 )
 
 // Defining the gauge vector for saving plans
@@ -46,38 +47,31 @@ func setServiceSavingsPlansSubscribedPlanSize(projectID string, instanceName str
 func updateServiceSavingsPlansSubscribed(ovhClient *ovh.Client, serviceID int, projectID string) {
 	logger.Info().Msgf("updating service savings plan subscription for service %d", serviceID)
 
-	// Retrieve the savings plans for the given service
-	savingsPlans, err := api.GetServicesSavingPlansSubscribed(ovhClient, serviceID)
+	err := RefreshScope(
+		ServiceScope{ServiceID: strconv.Itoa(serviceID)},
+		CollectorServicesSavingsPlansSubscribed,
+		func() ([]models.SavingsPlan, error) {
+			return api.GetServicesSavingPlansSubscribed(ovhClient, serviceID)
+		},
+		func(savingsPlan models.SavingsPlan) {
+			logger.Info().Msgf("processing savings plan %s for service %d", savingsPlan.ID, serviceID)
+			setServiceSavingsPlansSubscribedPlanSize(
+				projectID,
+				savingsPlan.DisplayName,
+				strconv.Itoa(serviceID),
+				savingsPlan.Period,
+				savingsPlan.Flavor,
+				savingsPlan.ID,
+				string(savingsPlan.Status),
+				savingsPlan.PeriodStartDate,
+				savingsPlan.PeriodEndDate,
+				savingsPlan.Size,
+			)
+		},
+		servicesSavingsPlansSubscribedPlanSize,
+	)
 	if err != nil {
-		apiErrors.WithLabelValues("services_savingsplans_subscribed").Inc()
 		logger.Error().Msgf("failed to retrieve savings plans for service %d: %v", serviceID, err)
-		return
-	}
-
-	// Check if savingsPlans slice is empty
-	if len(savingsPlans) == 0 {
-		logger.Warn().Msgf("no savings plans found for service %d", serviceID)
-		return
-	}
-
-	// Iterate through all savings plans (in case there are multiple)
-	for _, savingsPlan := range savingsPlans {
-		// Log each plan being processed
-		logger.Info().Msgf("processing savings plan %s for service %d", savingsPlan.ID, serviceID)
-
-		// Set the values in the Prometheus gauge for each plan
-		setServiceSavingsPlansSubscribedPlanSize(
-			projectID,
-			savingsPlan.DisplayName,
-			strconv.Itoa(serviceID),
-			savingsPlan.Period,
-			savingsPlan.Flavor,
-			savingsPlan.ID,
-			string(savingsPlan.Status),
-			savingsPlan.PeriodStartDate,
-			savingsPlan.PeriodEndDate,
-			savingsPlan.Size,
-		)
 	}
 }
 
@@ -92,7 +86,7 @@ func updateAllServicesSavingsPlansSubscribed(ovhClient *ovh.Client) {
 
 		result, err := api.GetServices(ovhClient, opts)
 		if err != nil {
-			apiErrors.WithLabelValues("services_savingsplans_subscribed").Inc()
+			apiErrors.WithLabelValues(CollectorServicesSavingsPlansSubscribed).Inc()
 			logger.Error().Msgf("error retrieving services for projectID %s: %v", projectID, err)
 			continue
 		}


### PR DESCRIPTION
updateMetrics used to Reset() every gauge then refill collector by
collector: any failed OVH API call left its whole scope absent from
/metrics for a full cache interval (4h), making downstream alerts
flap (SavingsPlan* alerts saw projects "lose" all their instances
~16 times per 48h in prod while nothing actually changed).

Each collector now deletes only the label scope it has just
successfully re-fetched (DeletePartialMatch by project_id, by
project_id+region, or by service_id) right before re-setting it, and
keeps the previous values when the fetch fails. Dedicated servers
keep a full Reset but only after the server list call succeeded.

Trade-off: series for scopes removed from the watch lists now persist
until the next pod restart instead of the next refresh.
