### PR TITLE
refactor(network): centralize env var names as constants and add unit tests

### DIFF
--- a/pkg/network/env.go
+++ b/pkg/network/env.go
@@ -1,0 +1,34 @@
+package network
+
+// Environment variable names read by the exporter. Kept as constants
+// instead of repeating the string at every os.Getenv call site so a typo
+// can't silently create a second, always-empty variable (e.g. reading
+// "OVH_CLOUD_PROJECT_INVENTORY_PROJECT_ID" somewhere would compile fine but
+// never resolve to any project).
+const (
+	// EnvOVHEndpoint, EnvOVHAppKey, EnvOVHAppSecret and EnvOVHConsumerKey are
+	// the go-ovh client credentials, see `ovh-exporter credentials`.
+	EnvOVHEndpoint    = "OVH_ENDPOINT"
+	EnvOVHAppKey      = "OVH_APP_KEY"
+	EnvOVHAppSecret   = "OVH_APP_SECRET"
+	EnvOVHConsumerKey = "OVH_CONSUMER_KEY"
+
+	// EnvOVHCloudProjectInstanceBillingProjectIDs and
+	// EnvOVHCloudProjectInventoryProjectIDs are comma-separated lists of OVH
+	// cloud project IDs, read by projectIDsFromEnv. They are two separate
+	// variables because billing and inventory collectors don't necessarily
+	// watch the same set of projects.
+	EnvOVHCloudProjectInstanceBillingProjectIDs = "OVH_CLOUD_PROJECT_INSTANCE_BILLING_PROJECT_IDS"
+	EnvOVHCloudProjectInventoryProjectIDs       = "OVH_CLOUD_PROJECT_INVENTORY_PROJECT_IDS"
+
+	// EnvOVHDedicatedServerSubscriptionEnabled disables the dedicated server
+	// subscription collector when set to "false".
+	EnvOVHDedicatedServerSubscriptionEnabled = "OVH_DEDICATED_SERVER_SUBSCRIPTION_ENABLED"
+
+	// EnvOVHCacheUpdateInterval is the refresh interval, in seconds, between
+	// two full metric collections.
+	EnvOVHCacheUpdateInterval = "OVH_CACHE_UPDATE_INTERVAL"
+
+	// EnvServerPort is the port the HTTP server listens on.
+	EnvServerPort = "SERVER_PORT"
+)

--- a/pkg/network/serve.go
+++ b/pkg/network/serve.go
@@ -76,10 +76,10 @@ func updateMetrics(ovhClient *ovh.Client) {
 }
 
 func setupCacheUpdater(ovhClient *ovh.Client) {
-	intervalStr := os.Getenv("OVH_CACHE_UPDATE_INTERVAL")
+	intervalStr := os.Getenv(EnvOVHCacheUpdateInterval)
 	intervalSeconds, err := strconv.Atoi(intervalStr)
 	if err != nil {
-		logger.Fatal().Msgf("failed to parse OVH_CACHE_UPDATE_INTERVAL: %v", err)
+		logger.Fatal().Msgf("failed to parse %s: %v", EnvOVHCacheUpdateInterval, err)
 	}
 	cacheUpdateInterval := time.Duration(intervalSeconds) * time.Second
 
@@ -99,10 +99,10 @@ func serveRoutes(ctx context.Context, cmd *cli.Command) error {
 	initializeMetrics()
 
 	ovhClient, err := ovh.NewClient(
-		os.Getenv("OVH_ENDPOINT"),
-		os.Getenv("OVH_APP_KEY"),
-		os.Getenv("OVH_APP_SECRET"),
-		os.Getenv("OVH_CONSUMER_KEY"),
+		os.Getenv(EnvOVHEndpoint),
+		os.Getenv(EnvOVHAppKey),
+		os.Getenv(EnvOVHAppSecret),
+		os.Getenv(EnvOVHConsumerKey),
 	)
 	if err != nil {
 		logger.Fatal().Msgf("failed to create OVH client: %v", err)
@@ -111,7 +111,7 @@ func serveRoutes(ctx context.Context, cmd *cli.Command) error {
 	http.HandleFunc("/ping", pingHandler)
 	http.Handle("/metrics", promhttp.Handler())
 
-	serverPort := os.Getenv("SERVER_PORT")
+	serverPort := os.Getenv(EnvServerPort)
 	formattedServerPort := fmt.Sprintf(":%s", serverPort)
 	logger.Info().Msgf("server started on port %s", formattedServerPort)
 

--- a/pkg/network/serve_cloud_project_floatingip.go
+++ b/pkg/network/serve_cloud_project_floatingip.go
@@ -69,7 +69,7 @@ func updateCloudProjectFloatingIPsPerProjectID(ovhClient *ovh.Client, projectID 
 }
 
 func updateCloudProjectFloatingIPs(ovhClient *ovh.Client) {
-	for _, projectID := range projectIDsFromEnv("OVH_CLOUD_PROJECT_INVENTORY_PROJECT_IDS") {
+	for _, projectID := range projectIDsFromEnv(EnvOVHCloudProjectInventoryProjectIDs) {
 		updateCloudProjectFloatingIPsPerProjectID(ovhClient, projectID)
 	}
 }

--- a/pkg/network/serve_cloud_project_info.go
+++ b/pkg/network/serve_cloud_project_info.go
@@ -51,7 +51,7 @@ func updateCloudProjectInfoPerProjectID(ovhClient *ovh.Client, projectID string)
 
 func updateCloudProjectInfo(ovhClient *ovh.Client) {
 	seen := make(map[string]bool)
-	for _, envVar := range []string{"OVH_CLOUD_PROJECT_INSTANCE_BILLING_PROJECT_IDS", "OVH_CLOUD_PROJECT_INVENTORY_PROJECT_IDS"} {
+	for _, envVar := range []string{EnvOVHCloudProjectInstanceBillingProjectIDs, EnvOVHCloudProjectInventoryProjectIDs} {
 		for _, projectID := range projectIDsFromEnv(envVar) {
 			if seen[projectID] {
 				continue

--- a/pkg/network/serve_cloud_project_instance_billing.go
+++ b/pkg/network/serve_cloud_project_instance_billing.go
@@ -91,7 +91,7 @@ func updateCloudProviderInstanceBillingPerProjectID(ovhClient *ovh.Client, proje
 }
 
 func updateCloudProviderInstanceBilling(ovhClient *ovh.Client) {
-	for _, projectID := range projectIDsFromEnv("OVH_CLOUD_PROJECT_INSTANCE_BILLING_PROJECT_IDS") {
+	for _, projectID := range projectIDsFromEnv(EnvOVHCloudProjectInstanceBillingProjectIDs) {
 		updateCloudProviderInstanceBillingPerProjectID(ovhClient, projectID)
 	}
 }

--- a/pkg/network/serve_cloud_project_loadbalancer.go
+++ b/pkg/network/serve_cloud_project_loadbalancer.go
@@ -60,7 +60,7 @@ func updateCloudProjectLoadBalancersPerProjectID(ovhClient *ovh.Client, projectI
 }
 
 func updateCloudProjectLoadBalancers(ovhClient *ovh.Client) {
-	for _, projectID := range projectIDsFromEnv("OVH_CLOUD_PROJECT_INVENTORY_PROJECT_IDS") {
+	for _, projectID := range projectIDsFromEnv(EnvOVHCloudProjectInventoryProjectIDs) {
 		updateCloudProjectLoadBalancersPerProjectID(ovhClient, projectID)
 	}
 }

--- a/pkg/network/serve_cloud_project_volume.go
+++ b/pkg/network/serve_cloud_project_volume.go
@@ -51,7 +51,7 @@ func updateCloudProjectVolumesPerProjectID(ovhClient *ovh.Client, projectID stri
 }
 
 func updateCloudProjectVolumes(ovhClient *ovh.Client) {
-	for _, projectID := range projectIDsFromEnv("OVH_CLOUD_PROJECT_INVENTORY_PROJECT_IDS") {
+	for _, projectID := range projectIDsFromEnv(EnvOVHCloudProjectInventoryProjectIDs) {
 		updateCloudProjectVolumesPerProjectID(ovhClient, projectID)
 	}
 }

--- a/pkg/network/serve_dedicated_server_subscription.go
+++ b/pkg/network/serve_dedicated_server_subscription.go
@@ -94,7 +94,7 @@ func updateDedicatedServerSubscription(ovhClient *ovh.Client, server models.Serv
 }
 
 func updateDedicatedServersSubscription(ovhClient *ovh.Client) {
-	if os.Getenv("OVH_DEDICATED_SERVER_SUBSCRIPTION_ENABLED") == "false" {
+	if os.Getenv(EnvOVHDedicatedServerSubscriptionEnabled) == "false" {
 		return
 	}
 

--- a/pkg/network/serve_services_savingsplans_subscribed.go
+++ b/pkg/network/serve_services_savingsplans_subscribed.go
@@ -78,7 +78,7 @@ func updateServiceSavingsPlansSubscribed(ovhClient *ovh.Client, serviceID int, p
 // Function to update the savings plan subscription for all services
 func updateAllServicesSavingsPlansSubscribed(ovhClient *ovh.Client) {
 	// Loop through each projectID in the projectIDList
-	for _, projectID := range projectIDsFromEnv("OVH_CLOUD_PROJECT_INSTANCE_BILLING_PROJECT_IDS") {
+	for _, projectID := range projectIDsFromEnv(EnvOVHCloudProjectInstanceBillingProjectIDs) {
 
 		opts := &api.Options{
 			ResourceName: &projectID,

--- a/pkg/network/serve_test.go
+++ b/pkg/network/serve_test.go
@@ -1,0 +1,40 @@
+package network
+
+import (
+	"testing"
+)
+
+// TestProjectIDsFromEnv pins down the parsing rules the OVH_CLOUD_PROJECT_*
+// env vars rely on: comma-separated, surrounding whitespace trimmed, empty
+// entries dropped (a trailing comma or an unset var must not produce a
+// bogus "" project ID that would then 404 against the OVH API).
+func TestProjectIDsFromEnv(t *testing.T) {
+	cases := map[string]struct {
+		value string
+		want  []string
+	}{
+		"unset env var yields no project IDs":     {value: "", want: nil},
+		"single project ID":                       {value: "abc123", want: []string{"abc123"}},
+		"multiple project IDs":                    {value: "abc123,def456", want: []string{"abc123", "def456"}},
+		"whitespace around IDs is trimmed":        {value: " abc123 , def456 ", want: []string{"abc123", "def456"}},
+		"empty entries from stray commas dropped": {value: "abc123,,def456,", want: []string{"abc123", "def456"}},
+		"blank value yields no project IDs":       {value: "   ", want: nil},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv(EnvOVHCloudProjectInventoryProjectIDs, tc.value)
+
+			got := projectIDsFromEnv(EnvOVHCloudProjectInventoryProjectIDs)
+
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("got %v, want %v", got, tc.want)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

- All environment variable names read by the exporter (`OVH_*`, `SERVER_PORT`) are now constants in `pkg/network/env.go` instead of repeated string literals across collector files. Prevents a typo from silently creating a second, always-empty variable.
- Unit tests for `projectIDsFromEnv` (comma-splitting, whitespace trimming, empty entries).

No behavior change.

## How to verify

```bash
go build ./... && go vet ./... && gofmt -l . && golangci-lint run ./... && go test ./...
```

This is a base for #54 (Cloudflare dangling-DNS check), which will be rebased on top of this branch once it merges.